### PR TITLE
Use `EntrySummaryDTO` for fields of `EntryDTO`

### DIFF
--- a/src/main/java/edu/stanford/slac/elog_plus/api/v1/dto/EntryDTO.java
+++ b/src/main/java/edu/stanford/slac/elog_plus/api/v1/dto/EntryDTO.java
@@ -34,11 +34,11 @@ public record EntryDTO(
         @Schema(description = "the attachments of the entry")
         List<AttachmentDTO> attachments,
         @Schema(description = "the follow up of the entry")
-        List<EntryDTO> followUps,
+        List<EntrySummaryDTO> followUps,
         @Schema(description = "the entry that this one follow up")
-        EntryDTO followingUp,
+        EntrySummaryDTO followingUp,
         @Schema(description = "the history of the entry")
-        List<EntryDTO> history,
+        List<EntrySummaryDTO> history,
         @Schema(description = "The shift which the entry belong, if any match the event date")
         List<LogbookShiftDTO> shifts,
         Boolean referencesInBody,

--- a/src/main/java/edu/stanford/slac/elog_plus/api/v1/dto/EntrySummaryDTO.java
+++ b/src/main/java/edu/stanford/slac/elog_plus/api/v1/dto/EntrySummaryDTO.java
@@ -37,6 +37,8 @@ public record EntrySummaryDTO(
         List<String> referencedBy,
         @Schema(description = "The id of the entry that is followUp for this the current entry is a follow ups")
         String followingUp,
+        @Schema(description = "The list of entries that are follow ups of the current entry")
+        List<String> followUps,
         @Schema(description = "The entry notes")
         String note,
         @JsonDeserialize(using = LocalDateTimeDeserializer.class)

--- a/src/test/java/edu/stanford/slac/elog_plus/v1/service/EntryServiceTest.java
+++ b/src/test/java/edu/stanford/slac/elog_plus/v1/service/EntryServiceTest.java
@@ -323,7 +323,7 @@ public class EntryServiceTest {
                                 sharedUtilityService.getPersonForEmail("user1@slac.stanford.edu")
                         )
                 );
-        List<EntryDTO> history = new ArrayList<>();
+        List<EntrySummaryDTO> history = new ArrayList<>();
         assertDoesNotThrow(
                 () -> entryService.getLogHistory(supersededLogIDNewest, history)
         );


### PR DESCRIPTION
The frontend does not need `EntryDTO` for fields `followUps`, `followingUp`, and `history`. I've also added `followUps` to `EntrySummaryDTO` with the IDs.

Furthermore, I've removed the check for `getAllFollowUpForALog` that throws an error if there are no follow ups. Since it is fine to just return an empty list.